### PR TITLE
docs: fix quickstart link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As of now, the following limitations apply to `argocd-agent`:
 
 ## Quickstart
 
-See the [quickstart guide](docs/quickstart.md) for more information.
+See the [quickstart guide](docs/hack/quickstart.md) for more information.
 
 ## Compatibility
 


### PR DESCRIPTION
Simple fix to the README file where the quickstart guide link is pointing at the wrong path.