### PR TITLE
feat: Support setting log format

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -24,6 +24,7 @@ func NewAgentRunCommand() *cobra.Command {
 		serverAddress string
 		serverPort    int
 		logLevel      string
+		logFormat     string
 		insecure      bool
 		rootCAPath    string
 		kubeConfig    string
@@ -58,6 +59,11 @@ func NewAgentRunCommand() *cobra.Command {
 					cmd.Fatal("invalid log level: %s. Available levels are: %s", logLevel, cmd.AvailableLogLevels())
 				}
 				logrus.SetLevel(lvl)
+			}
+			if formatter, err := cmd.LogFormatter(logFormat); err != nil {
+				cmd.Fatal(err.Error())
+			} else {
+				logrus.SetFormatter(formatter)
 			}
 			if creds != "" {
 				authMethod, authCreds, err := parseCreds(creds)
@@ -113,6 +119,9 @@ func NewAgentRunCommand() *cobra.Command {
 	command.Flags().StringVar(&logLevel, "log-level",
 		env.StringWithDefault("ARGOCD_AGENT_LOG_LEVEL", nil, "info"),
 		"The log level for the agent")
+	command.Flags().StringVar(&logFormat, "log-format",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_LOG_FORMAT", nil, "text"),
+		"The log format to use (one of: text, json)")
 	command.Flags().BoolVar(&insecure, "insecure-tls",
 		env.BoolWithDefault("ARGOCD_AGENT_TLS_INSECURE", false),
 		"INSECURE: Do not verify remote TLS certificate")

--- a/cmd/cmd/log.go
+++ b/cmd/cmd/log.go
@@ -60,3 +60,14 @@ func InitLogging() {
 		},
 	})
 }
+
+func LogFormatter(format string) (logrus.Formatter, error) {
+	switch strings.ToLower(format) {
+	case "text":
+		return &logrus.TextFormatter{}, nil
+	case "json":
+		return &logrus.JSONFormatter{}, nil
+	default:
+		return nil, fmt.Errorf("invalid format '%s', must be one of text, json", format)
+	}
+}

--- a/cmd/principal/main.go
+++ b/cmd/principal/main.go
@@ -21,6 +21,7 @@ func NewPrincipalRunCommand() *cobra.Command {
 		listenHost             string
 		listenPort             int
 		logLevel               string
+		logFormat              string
 		metricsPort            int
 		disableMetrics         bool
 		namespace              string
@@ -50,6 +51,11 @@ func NewPrincipalRunCommand() *cobra.Command {
 					cmd.Fatal("invalid log level: %s. Available levels are: %s", logLevel, cmd.AvailableLogLevels())
 				}
 				logrus.SetLevel(lvl)
+			}
+			if formatter, err := cmd.LogFormatter(logFormat); err != nil {
+				cmd.Fatal(err.Error())
+			} else {
+				logrus.SetFormatter(formatter)
 			}
 
 			kubeConfig, err := cmd.GetKubeConfig(ctx, namespace, kubeConfig, kubeContext)
@@ -146,6 +152,9 @@ func NewPrincipalRunCommand() *cobra.Command {
 	command.Flags().StringVar(&logLevel, "log-level",
 		env.StringWithDefault("ARGOCD_PRINCIPAL_LOG_LEVEL", nil, logrus.InfoLevel.String()),
 		"The log level to use")
+	command.Flags().StringVar(&logFormat, "log-format",
+		env.StringWithDefault("ARGOCD_PRINCIPAL_LOG_FORMAT", nil, "text"),
+		"The log format to use (one of: text, json)")
 
 	command.Flags().IntVar(&metricsPort, "metrics-port",
 		env.NumWithDefault("ARGOCD_PRINCIPAL_METRICS_PORT", cmd.ValidPort, 8000),


### PR DESCRIPTION
New command line parameter `--log-format` for agent and principal.

For now, accepts one of `text` and `json` arguments to set log format accordingly.